### PR TITLE
#161213906 add endpoint to get single product

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ from flask import Blueprint
 from flask_restful import Api
 
 # local imports
-from app.api.v1.views import Home, Products
+from app.api.v1.views import Home, Products, SingleProduct
 
 
 api_bp = Blueprint('api', __name__)
@@ -11,3 +11,5 @@ api = Api(api_bp)
 # Routes
 api.add_resource(Home, '/home')
 api.add_resource(Products, '/products')
+api.add_resource(SingleProduct, '/products/<int:productID>')
+

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -1,14 +1,6 @@
-from flask_restful import Resource
+from flask_restful import Resource, reqparse
 
-products = [{
-        'id': 1,
-        'title': "Coming soon",
-        'description': "LOrem ipsum",
-        'price': 100,
-        'quantity': 20,
-        'minimun': 5,
-        'image_url':'coming_soon'
-    }]
+books = [{"id":1}]
 
 class Home(Resource):
   """Just a test endpoint ~/dann/api/v1/home"""
@@ -20,7 +12,16 @@ class Products(Resource):
   """docstring for Products"""
   """ endpoint for GET requests to /dann/api/v1/products"""
   def get(self):
-    if len(products) != 0:
-      return {"Books" : products}, 200
+    if len(books) != 0:
+      return {"Books" : books}, 200
     else:
       return {"Error": "There are no books"}, 404
+
+class SingleProduct(Resource):
+  """docstring for SingleProduct"""
+  """ endpoint for GET requests to /dann/api/v1/products/<productID>"""
+  def get(self, productID):
+    book = [book for book in books if book['id'] == productID]
+    if len(book) == 0:
+      return {'Error':'That book does not exist'}, 404
+    return {'order': book[0]}, 200

--- a/app/tests/v1/test_v1.py
+++ b/app/tests/v1/test_v1.py
@@ -37,5 +37,13 @@ class Apiv1Test(unittest.TestCase):
     self.assertEqual(json_data.get('Error'), "There are no books")
     self.assertEqual(response.status_code, 404)
 
+  def test_get_non_existent_product_by_id(self):
+    """Tests /products/productID endpoint. There are no items yet"""
+    response = self.client().get('/dann/api/v1/products/0')
+    json_data = json.loads(response.data)
+    self.assertTrue(json_data.get('Error'))
+    self.assertEqual(json_data.get('Error'), "That book does not exist")
+    self.assertEqual(response.status_code, 404)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
#### What does this PR do?
Add GET /products/<productId> endpoint

#### Description of Task to be completed?
Add an endpoint to get a single book by its ID

#### How should this be manually tested?
* Set up the app locally as described in the installation documentation
* Use postman to send a POST request to http://localhost:5000/dann/api/v1/products 
* The POST request should have a body with the format of  ```{
        'title': "str",
        'description': "str",
        'price': int,
        'quantity': int
        'minimun': int,
        'image_url':'str'
    }```
* You may now send a GET request to http://localhost:5000/dann/api/v1/products/1
* You should get a response containing the details of the product

#### Any background context you want to provide?
* Requires POST endpoint to be working - added in a previous pr

#### What are the relevant pivotal tracker stories?
[#161213906](https://www.pivotaltracker.com/story/show/161213906)

